### PR TITLE
Add backend-agnostic quotation memory store with Qdrant fallback and feature flags

### DIFF
--- a/docs/mcp/qdrant-rollout.md
+++ b/docs/mcp/qdrant-rollout.md
@@ -1,0 +1,51 @@
+# Qdrant rollout guide for `quotation_store`
+
+This document defines when to keep the default `FileStore` and when to enable `QdrantStore` for quotation memory.
+
+## Feature flags
+
+Set these in environment variables (or default them in `mcp/config/mcp_server_config.json`):
+
+- `ENABLE_QDRANT_MEMORY`: turns on Qdrant as preferred backend.
+- `ENABLE_VECTOR_RETRIEVAL`: enables similar-quotation retrieval responses.
+
+## Cost and latency breakpoints
+
+Use these thresholds as rollout guardrails:
+
+| Workload profile | Recommended backend | Why |
+| --- | --- | --- |
+| **< 1,000 quotations/month** and **< 3 concurrent users** | `FileStore` | Near-zero infra cost, predictable local writes, no network dependency. |
+| **1,000–10,000 quotations/month** or **3–15 concurrent users** | `FileStore` initially, then pilot `QdrantStore` | File search remains acceptable, but retrieval latency can start increasing with larger history. |
+| **> 10,000 quotations/month** or **> 15 concurrent users** | `QdrantStore` | Vector index keeps retrieval bounded and supports better semantic matching quality. |
+| **P95 retrieval SLA < 150 ms** over WAN | `QdrantStore` | Remote vector DB can outperform file scans when tuned and colocated. |
+| **Budget constraint < $10/month** and low request volume | `FileStore` | Avoid managed vector DB spending until usage justifies it. |
+
+### Rule of thumb
+
+Enable Qdrant when **either**:
+
+1. Similarity retrieval requests exceed **100/day**, or
+2. Local file retrieval P95 exceeds **250 ms** for a week, or
+3. Memory dataset exceeds **~50 MB** serialized JSON.
+
+If none of the above are true, keep `FileStore`.
+
+## Startup degradation behavior
+
+When `ENABLE_QDRANT_MEMORY=true`:
+
+1. Server attempts a Qdrant health check (`GET /collections`).
+2. If it fails, server automatically falls back to `FileStore`.
+3. A structured warning is emitted:
+
+```json
+{
+  "event": "memory_backend_degraded",
+  "requested_backend": "qdrant",
+  "active_backend": "file",
+  "reason": "...connection error..."
+}
+```
+
+This ensures `quotation_store` callers receive the same response shape regardless of backend.

--- a/mcp/__init__.py
+++ b/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""GPT-PANELIN MCP server package."""

--- a/mcp/config/mcp_server_config.json
+++ b/mcp/config/mcp_server_config.json
@@ -7,8 +7,23 @@
     "tools/price_check.json",
     "tools/catalog_search.json",
     "tools/bom_calculate.json",
-    "tools/report_error.json"
+    "tools/report_error.json",
+    "tools/quotation_store.json"
   ],
+  "feature_flags": {
+    "ENABLE_QDRANT_MEMORY": false,
+    "ENABLE_VECTOR_RETRIEVAL": false
+  },
+  "memory": {
+    "default_backend": "file",
+    "file_store_path": "../quotation_memory.json",
+    "qdrant": {
+      "url": "http://localhost:6333",
+      "api_key_env": "QDRANT_API_KEY",
+      "collection": "panelin_quotations",
+      "timeout_seconds": 2
+    }
+  },
   "kb_paths": {
     "pricing_master": "../bromyros_pricing_master.json",
     "pricing_optimized": "../bromyros_pricing_gpt_optimized.json",

--- a/mcp/config/settings.py
+++ b/mcp/config/settings.py
@@ -1,0 +1,77 @@
+"""Centralized runtime configuration for MCP server feature flags and memory providers."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CONFIG_FILE = Path(__file__).with_name("mcp_server_config.json")
+
+
+@dataclass(frozen=True)
+class FeatureFlags:
+    enable_qdrant_memory: bool
+    enable_vector_retrieval: bool
+
+
+@dataclass(frozen=True)
+class MemoryConfig:
+    file_store_path: Path
+    qdrant_url: str
+    qdrant_api_key: str | None
+    qdrant_collection: str
+    qdrant_timeout_seconds: float
+
+
+@dataclass(frozen=True)
+class RuntimeSettings:
+    feature_flags: FeatureFlags
+    memory: MemoryConfig
+
+
+
+def _as_bool(value: Any, default: bool) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+
+def load_runtime_settings() -> RuntimeSettings:
+    with open(CONFIG_FILE, encoding="utf-8") as f:
+        config = json.load(f)
+
+    flags = config.get("feature_flags", {})
+    memory = config.get("memory", {})
+    qdrant = memory.get("qdrant", {})
+
+    enable_qdrant_default = _as_bool(flags.get("ENABLE_QDRANT_MEMORY"), False)
+    enable_retrieval_default = _as_bool(flags.get("ENABLE_VECTOR_RETRIEVAL"), False)
+
+    enable_qdrant_memory = _as_bool(os.getenv("ENABLE_QDRANT_MEMORY"), enable_qdrant_default)
+    enable_vector_retrieval = _as_bool(os.getenv("ENABLE_VECTOR_RETRIEVAL"), enable_retrieval_default)
+
+    file_store_relative = memory.get("file_store_path", "../quotation_memory.json")
+    file_store_path = (CONFIG_FILE.parent / file_store_relative).resolve()
+
+    api_key_env = qdrant.get("api_key_env", "QDRANT_API_KEY")
+    qdrant_api_key = os.getenv(api_key_env)
+
+    return RuntimeSettings(
+        feature_flags=FeatureFlags(
+            enable_qdrant_memory=enable_qdrant_memory,
+            enable_vector_retrieval=enable_vector_retrieval,
+        ),
+        memory=MemoryConfig(
+            file_store_path=file_store_path,
+            qdrant_url=os.getenv("QDRANT_URL", qdrant.get("url", "http://localhost:6333")),
+            qdrant_api_key=qdrant_api_key,
+            qdrant_collection=os.getenv("QDRANT_COLLECTION", qdrant.get("collection", "panelin_quotations")),
+            qdrant_timeout_seconds=float(qdrant.get("timeout_seconds", 2)),
+        ),
+    )

--- a/mcp/handlers/__init__.py
+++ b/mcp/handlers/__init__.py
@@ -5,4 +5,5 @@ Each module implements one MCP tool:
 - catalog: catalog_search tool
 - bom: bom_calculate tool
 - errors: report_error tool
+- quotation: quotation_store tool
 """

--- a/mcp/handlers/quotation.py
+++ b/mcp/handlers/quotation.py
@@ -1,0 +1,45 @@
+"""Handler for quotation_store tool with backend-agnostic behavior."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.storage.memory_store import MemoryStore
+
+_memory_store: MemoryStore | None = None
+_enable_vector_retrieval = False
+
+
+def configure_quotation_store(store: MemoryStore, enable_vector_retrieval: bool) -> None:
+    global _memory_store, _enable_vector_retrieval
+    _memory_store = store
+    _enable_vector_retrieval = enable_vector_retrieval
+
+
+async def handle_quotation_store(arguments: dict[str, Any]) -> dict[str, Any]:
+    if _memory_store is None:
+        return {"error": "quotation_store backend is not configured"}
+
+    quotation = arguments.get("quotation")
+    embedding = arguments.get("embedding")
+    include_similar = bool(arguments.get("include_similar", False))
+    limit = int(arguments.get("limit", 3))
+
+    if not isinstance(quotation, dict):
+        return {"error": "quotation (object) is required"}
+    if not isinstance(embedding, list) or not embedding:
+        return {"error": "embedding (number[]) is required"}
+
+    normalized_embedding = [float(x) for x in embedding]
+    store_result = await _memory_store.save_quotation(quotation, normalized_embedding)
+
+    similar: list[dict[str, Any]] = []
+    if include_similar and _enable_vector_retrieval:
+        similar = await _memory_store.retrieve_similar(normalized_embedding, max(1, min(limit, 10)))
+
+    return {
+        "message": "Quotation stored successfully",
+        "quotation_id": store_result["quotation_id"],
+        "timestamp": store_result["timestamp"],
+        "similar_quotations": similar,
+    }

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -4,3 +4,4 @@ uvicorn>=0.30.0
 starlette>=0.40.0
 httpx>=0.27.0
 pydantic>=2.0.0
+requests>=2.31.0

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -37,6 +37,8 @@ from .handlers.pricing import handle_price_check
 from .handlers.catalog import handle_catalog_search
 from .handlers.bom import handle_bom_calculate
 from .handlers.errors import handle_report_error
+from .handlers.quotation import configure_quotation_store, handle_quotation_store
+from .storage.factory import initialize_memory_store
 
 TOOLS_DIR = Path(__file__).parent / "tools"
 
@@ -54,6 +56,7 @@ TOOL_HANDLERS = {
     "catalog_search": handle_catalog_search,
     "bom_calculate": handle_bom_calculate,
     "report_error": handle_report_error,
+    "quotation_store": handle_quotation_store,
 }
 
 TOOL_NAMES = list(TOOL_HANDLERS.keys())
@@ -69,6 +72,11 @@ def create_server() -> Any:
         sys.exit(1)
 
     server = Server("panelin-mcp-server")
+    memory_store, store_metadata = initialize_memory_store()
+    configure_quotation_store(
+        memory_store,
+        enable_vector_retrieval=bool(store_metadata.get("enable_vector_retrieval", False)),
+    )
 
     @server.list_tools()
     async def list_tools() -> list[Tool]:

--- a/mcp/storage/__init__.py
+++ b/mcp/storage/__init__.py
@@ -1,0 +1,1 @@
+"""Storage backends for quotation memory."""

--- a/mcp/storage/factory.py
+++ b/mcp/storage/factory.py
@@ -1,0 +1,46 @@
+"""Memory store selection and startup validation."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from mcp.config.settings import load_runtime_settings
+from mcp.storage.memory_store import FileStore, MemoryStore, QdrantStore
+
+logger = logging.getLogger(__name__)
+
+
+def initialize_memory_store() -> tuple[MemoryStore, dict[str, Any]]:
+    settings = load_runtime_settings()
+    flags = settings.feature_flags
+
+    file_store = FileStore(settings.memory.file_store_path)
+    metadata = {
+        "active_backend": "file",
+        "enable_vector_retrieval": flags.enable_vector_retrieval,
+    }
+
+    if not flags.enable_qdrant_memory:
+        return file_store, metadata
+
+    qdrant_store = QdrantStore(
+        url=settings.memory.qdrant_url,
+        collection=settings.memory.qdrant_collection,
+        timeout_seconds=settings.memory.qdrant_timeout_seconds,
+        api_key=settings.memory.qdrant_api_key,
+    )
+    try:
+        qdrant_store.healthcheck()
+        metadata["active_backend"] = "qdrant"
+        return qdrant_store, metadata
+    except Exception as exc:  # noqa: BLE001 - deliberate startup degrade behavior
+        warning_payload = {
+            "event": "memory_backend_degraded",
+            "requested_backend": "qdrant",
+            "active_backend": "file",
+            "reason": str(exc),
+        }
+        logger.warning(json.dumps(warning_payload, ensure_ascii=False))
+        return file_store, metadata

--- a/mcp/storage/memory_store.py
+++ b/mcp/storage/memory_store.py
@@ -1,0 +1,167 @@
+"""Storage abstraction for quotation memory backends."""
+
+from __future__ import annotations
+
+import json
+import math
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Protocol
+
+import requests
+
+
+@dataclass
+class StoredQuotation:
+    quotation_id: str
+    timestamp: str
+    payload: dict[str, Any]
+    embedding: list[float]
+
+
+class MemoryStore(Protocol):
+    async def save_quotation(self, payload: dict[str, Any], embedding: list[float]) -> dict[str, Any]:
+        ...
+
+    async def retrieve_similar(self, embedding: list[float], limit: int) -> list[dict[str, Any]]:
+        ...
+
+
+class FileStore:
+    """JSON file backed memory store used as default fallback backend."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _load_items(self) -> list[dict[str, Any]]:
+        if not self.path.exists():
+            return []
+        with open(self.path, encoding="utf-8") as f:
+            raw = json.load(f)
+        return raw.get("items", []) if isinstance(raw, dict) else []
+
+    def _save_items(self, items: list[dict[str, Any]]) -> None:
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump({"items": items}, f, ensure_ascii=False, indent=2)
+
+    async def save_quotation(self, payload: dict[str, Any], embedding: list[float]) -> dict[str, Any]:
+        items = self._load_items()
+        record = StoredQuotation(
+            quotation_id=f"Q-{uuid.uuid4().hex[:10]}",
+            timestamp=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            payload=payload,
+            embedding=embedding,
+        )
+        items.append(record.__dict__)
+        self._save_items(items)
+        return {
+            "quotation_id": record.quotation_id,
+            "timestamp": record.timestamp,
+            "status": "stored",
+        }
+
+    async def retrieve_similar(self, embedding: list[float], limit: int) -> list[dict[str, Any]]:
+        if not embedding:
+            return []
+        items = self._load_items()
+        scored: list[tuple[float, dict[str, Any]]] = []
+        for item in items:
+            vector = item.get("embedding") or []
+            if not isinstance(vector, list) or not vector:
+                continue
+            score = _cosine_similarity(embedding, [float(v) for v in vector])
+            scored.append((score, item))
+        scored.sort(key=lambda s: s[0], reverse=True)
+        return [
+            {
+                "quotation_id": item["quotation_id"],
+                "timestamp": item["timestamp"],
+                "score": round(score, 4),
+                "payload": item["payload"],
+            }
+            for score, item in scored[:limit]
+        ]
+
+
+class QdrantStore:
+    """Qdrant-backed memory store."""
+
+    def __init__(self, url: str, collection: str, timeout_seconds: float, api_key: str | None = None):
+        self.url = url.rstrip("/")
+        self.collection = collection
+        self.timeout_seconds = timeout_seconds
+        self.session = requests.Session()
+        if api_key:
+            self.session.headers.update({"api-key": api_key})
+
+    def healthcheck(self) -> None:
+        response = self.session.get(f"{self.url}/collections", timeout=self.timeout_seconds)
+        response.raise_for_status()
+
+    async def save_quotation(self, payload: dict[str, Any], embedding: list[float]) -> dict[str, Any]:
+        quotation_id = f"Q-{uuid.uuid4().hex[:10]}"
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        point = {
+            "points": [
+                {
+                    "id": quotation_id,
+                    "vector": embedding,
+                    "payload": {
+                        "quotation_id": quotation_id,
+                        "timestamp": timestamp,
+                        "data": payload,
+                    },
+                }
+            ]
+        }
+        response = self.session.put(
+            f"{self.url}/collections/{self.collection}/points",
+            json=point,
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        return {
+            "quotation_id": quotation_id,
+            "timestamp": timestamp,
+            "status": "stored",
+        }
+
+    async def retrieve_similar(self, embedding: list[float], limit: int) -> list[dict[str, Any]]:
+        query = {
+            "vector": embedding,
+            "limit": limit,
+            "with_payload": True,
+        }
+        response = self.session.post(
+            f"{self.url}/collections/{self.collection}/points/search",
+            json=query,
+            timeout=self.timeout_seconds,
+        )
+        response.raise_for_status()
+        points = response.json().get("result", [])
+        return [
+            {
+                "quotation_id": p.get("payload", {}).get("quotation_id", p.get("id")),
+                "timestamp": p.get("payload", {}).get("timestamp"),
+                "score": round(float(p.get("score", 0)), 4),
+                "payload": p.get("payload", {}).get("data", {}),
+            }
+            for p in points
+        ]
+
+
+def _cosine_similarity(v1: list[float], v2: list[float]) -> float:
+    size = min(len(v1), len(v2))
+    if size == 0:
+        return 0.0
+    a = v1[:size]
+    b = v2[:size]
+    numerator = sum(x * y for x, y in zip(a, b))
+    den_a = math.sqrt(sum(x * x for x in a))
+    den_b = math.sqrt(sum(y * y for y in b))
+    if den_a == 0 or den_b == 0:
+        return 0.0
+    return numerator / (den_a * den_b)

--- a/mcp/tools/quotation_store.json
+++ b/mcp/tools/quotation_store.json
@@ -1,0 +1,33 @@
+{
+  "name": "quotation_store",
+  "description": "Store quotation payloads with embeddings and optionally retrieve similar historical quotations.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "quotation": {
+        "type": "object",
+        "description": "Structured quotation payload to persist."
+      },
+      "embedding": {
+        "type": "array",
+        "description": "Embedding vector associated with the quotation.",
+        "items": {
+          "type": "number"
+        }
+      },
+      "include_similar": {
+        "type": "boolean",
+        "description": "Whether to return similar stored quotations in the response.",
+        "default": false
+      },
+      "limit": {
+        "type": "integer",
+        "description": "Maximum similar quotations to return.",
+        "default": 3,
+        "minimum": 1,
+        "maximum": 10
+      }
+    },
+    "required": ["quotation", "embedding"]
+  }
+}


### PR DESCRIPTION
### Motivation

- Provide configurable runtime flags to enable/disable vector memory and retrieval behavior for the MCP server.  
- Introduce a storage abstraction so quotation persistence and similarity retrieval can switch between a local fallback and an optional vector DB backend.  
- Ensure callers of the `quotation_store` tool receive a stable response shape while enabling safe rollouts of Qdrant with automatic degradation on startup failures.

### Description

- Add centralized runtime loading in `mcp/config/settings.py` and new feature flags `ENABLE_QDRANT_MEMORY` and `ENABLE_VECTOR_RETRIEVAL` (config + env override).  
- Implement `MemoryStore` abstraction with `FileStore` (JSON file fallback) and `QdrantStore` (HTTP-based Qdrant integration) in `mcp/storage/memory_store.py`.  
- Wire up `initialize_memory_store()` in `mcp/storage/factory.py` that prefers Qdrant when enabled but falls back to `FileStore` and emits a structured `memory_backend_degraded` warning when healthchecks fail.  
- Add `quotation_store` MCP tool schema and backend-agnostic handler in `mcp/handlers/quotation.py`, and register the tool at server startup in `mcp/server.py`; also add rollout docs in `docs/mcp/qdrant-rollout.md` and `requests` to `mcp/requirements.txt` for Qdrant HTTP calls.

### Testing

- Ran `python -m compileall mcp` which succeeded (byte-compiled new modules).  
- Installed `requests` via `pip install requests` to satisfy runtime dependency which succeeded.  
- Simulated startup with `ENABLE_QDRANT_MEMORY=true` and an invalid `QDRANT_URL` which triggered automatic fallback to `FileStore` and emitted the structured `memory_backend_degraded` warning as expected.  
- Executed a handler smoke test by configuring a `FileStore` and calling `handle_quotation_store(...)` which returned the expected success message and stored quotation metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ff00e8e30832e8e7a85e3ad62a20c)