### PR TITLE
Add MCP observability: metrics schema, structured tool logging, daily cost rollups, and alerts

### DIFF
--- a/docs/mcp/observability.md
+++ b/docs/mcp/observability.md
@@ -1,0 +1,52 @@
+# MCP Observability Dashboard Spec
+
+Concise spec for Ops to validate performance and ROI after introducing **GitHub MCP** and **Qdrant MCP**.
+
+## 1) Data sources
+
+- Structured invocation logs: `observability/logs/tool_invocations.ndjson`.
+- Metrics contract: `observability/metrics_schema.json`.
+- Daily rollup: `observability/daily_cost_report.py` output in `observability/reports/`.
+- Baselines: `MCP_SERVER_COMPARATIVE_ANALYSIS.md`.
+
+## 2) Dashboard panels (minimum viable)
+
+1. **Cost per Session (Daily)**
+   - Metric: `per_session_average_token_cost_usd`
+   - Overlay baselines: low ($0.010000), high ($0.024667)
+   - Goal: stay at or below high baseline.
+
+2. **Token Volume by Session**
+   - Metric: input/output tokens by `session_id`
+   - View: daily heatmap + p95 session.
+
+3. **Tool Reliability**
+   - Metrics: tool call count, latency p50/p95, error rate by `error_code`
+   - Goal: tool failure <= 3% warning / <= 5% hard stop.
+
+4. **Cache Efficiency**
+   - Metric: hit/miss ratio by tool
+   - Goal: trending upward after cache tuning.
+
+5. **ROI: GitHub + Qdrant Additions**
+   - GitHub ROI proxy: reduction in unknown tool/config errors + KB sync incidents.
+   - Qdrant ROI proxy: lower repeat-session token costs and shorter average latency.
+   - Compare last 7 days vs pre-rollout baseline.
+
+## 3) KPI definitions
+
+- **Cost/session:** total token cost for all successful tool calls in session / number of sessions.
+- **Tool failure rate:** failed calls / total calls per tool per day.
+- **Cache hit ratio:** hits / (hits + misses).
+- **Qdrant ROI indicator:** `% drop in returning-session avg token cost`.
+- **GitHub ROI indicator:** `% drop in KB drift / config-related incidents`.
+
+## 4) Alert policy linkage
+
+Use `observability/threshold_alerts.md` gating rules:
+- If cost/session crosses pause threshold or any tool exceeds failure threshold, **pause rollout stage**.
+
+## 5) Cadence
+
+- Daily 09:00 UTC: run rollup report and review dashboard.
+- Weekly: compare 7-day trend vs MCP baseline scenario in comparative analysis.

--- a/mcp/observability.py
+++ b/mcp/observability.py
@@ -1,0 +1,148 @@
+"""Observability utilities for MCP tool invocation telemetry."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LOG_PATH = Path("observability/logs/tool_invocations.ndjson")
+
+
+@dataclass(frozen=True)
+class ToolInvocationContext:
+    """Context describing a single tool invocation lifecycle."""
+
+    session_id: str
+    tool_name: str
+    request_id: str
+    cache_status: str | None = None
+
+
+class JsonLineFormatter(logging.Formatter):
+    """Formatter that writes logging records as compact JSON lines."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "level": record.levelname,
+            "event": getattr(record, "event", "log"),
+            "message": record.getMessage(),
+            "tool_name": getattr(record, "tool_name", None),
+            "request_id": getattr(record, "request_id", None),
+            "session_id": getattr(record, "session_id", None),
+            "latency_ms": getattr(record, "latency_ms", None),
+            "cache_status": getattr(record, "cache_status", None),
+            "token_input": getattr(record, "token_input", None),
+            "token_output": getattr(record, "token_output", None),
+            "error_code": getattr(record, "error_code", None),
+        }
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def _build_logger() -> logging.Logger:
+    logger = logging.getLogger("mcp.observability")
+    if logger.handlers:
+        return logger
+
+    logger.setLevel(logging.INFO)
+    log_path = Path(os.environ.get("MCP_TOOL_LOG_PATH", DEFAULT_LOG_PATH))
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    file_handler = logging.FileHandler(log_path, encoding="utf-8")
+    file_handler.setFormatter(JsonLineFormatter())
+    logger.addHandler(file_handler)
+    logger.propagate = False
+    return logger
+
+
+LOGGER = _build_logger()
+
+
+def get_invocation_context(tool_name: str, arguments: dict[str, Any]) -> ToolInvocationContext:
+    """Create invocation context using known argument keys, with safe defaults."""
+    session_id = (
+        str(arguments.get("session_id"))
+        if arguments.get("session_id")
+        else str(arguments.get("client_id") or "unknown")
+    )
+    request_id = (
+        str(arguments.get("request_id"))
+        if arguments.get("request_id")
+        else f"req-{int(time.time() * 1000)}"
+    )
+    cache_status = arguments.get("cache_status")
+    return ToolInvocationContext(
+        session_id=session_id,
+        tool_name=tool_name,
+        request_id=request_id,
+        cache_status=str(cache_status) if cache_status else None,
+    )
+
+
+def log_tool_invocation_start(context: ToolInvocationContext, token_input: int | None) -> float:
+    """Log start event and return monotonic timer for duration measurement."""
+    start_time = time.perf_counter()
+    LOGGER.info(
+        "tool invocation started",
+        extra={
+            "event": "tool_invocation_start",
+            "tool_name": context.tool_name,
+            "request_id": context.request_id,
+            "session_id": context.session_id,
+            "cache_status": context.cache_status,
+            "token_input": token_input,
+        },
+    )
+    return start_time
+
+
+def log_tool_invocation_success(
+    context: ToolInvocationContext,
+    start_time: float,
+    token_input: int | None,
+    token_output: int | None,
+) -> None:
+    """Log successful completion with latency and token totals."""
+    latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
+    LOGGER.info(
+        "tool invocation completed",
+        extra={
+            "event": "tool_invocation_success",
+            "tool_name": context.tool_name,
+            "request_id": context.request_id,
+            "session_id": context.session_id,
+            "latency_ms": latency_ms,
+            "cache_status": context.cache_status,
+            "token_input": token_input,
+            "token_output": token_output,
+        },
+    )
+
+
+def log_tool_invocation_error(
+    context: ToolInvocationContext,
+    start_time: float,
+    error_code: str,
+    token_input: int | None,
+) -> None:
+    """Log failed completion with latency and normalized error code."""
+    latency_ms = round((time.perf_counter() - start_time) * 1000, 2)
+    LOGGER.error(
+        "tool invocation failed",
+        extra={
+            "event": "tool_invocation_error",
+            "tool_name": context.tool_name,
+            "request_id": context.request_id,
+            "session_id": context.session_id,
+            "latency_ms": latency_ms,
+            "cache_status": context.cache_status,
+            "token_input": token_input,
+            "error_code": error_code,
+        },
+    )

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -37,6 +37,12 @@ from .handlers.pricing import handle_price_check
 from .handlers.catalog import handle_catalog_search
 from .handlers.bom import handle_bom_calculate
 from .handlers.errors import handle_report_error
+from .observability import (
+    get_invocation_context,
+    log_tool_invocation_error,
+    log_tool_invocation_start,
+    log_tool_invocation_success,
+)
 
 TOOLS_DIR = Path(__file__).parent / "tools"
 
@@ -57,6 +63,12 @@ TOOL_HANDLERS = {
 }
 
 TOOL_NAMES = list(TOOL_HANDLERS.keys())
+
+
+def _estimate_token_count(payload: Any) -> int:
+    """Estimate token count using a conservative character heuristic."""
+    serialized = json.dumps(payload, ensure_ascii=False, default=str)
+    return max(1, round(len(serialized) / 4))
 
 
 def create_server() -> Any:
@@ -86,11 +98,24 @@ def create_server() -> Any:
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        context = get_invocation_context(name, arguments)
+        token_input = _estimate_token_count(arguments)
+        started_at = log_tool_invocation_start(context, token_input)
+
         handler = TOOL_HANDLERS.get(name)
         if not handler:
+            log_tool_invocation_error(context, started_at, "UNKNOWN_TOOL", token_input)
             return [TextContent(type="text", text=json.dumps({"error": f"Unknown tool: {name}"}))]
 
-        result = await handler(arguments)
+        try:
+            result = await handler(arguments)
+        except Exception as exc:  # noqa: BLE001
+            error_code = getattr(exc, "code", exc.__class__.__name__.upper())
+            log_tool_invocation_error(context, started_at, str(error_code), token_input)
+            raise
+
+        token_output = _estimate_token_count(result)
+        log_tool_invocation_success(context, started_at, token_input, token_output)
         return [TextContent(type="text", text=json.dumps(result, ensure_ascii=False, default=str))]
 
     return server

--- a/observability/daily_cost_report.py
+++ b/observability/daily_cost_report.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Generate daily MCP cost and reliability rollup from structured invocation logs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Baselines sourced from MCP_SERVER_COMPARATIVE_ANALYSIS.md (Cost-Efficient Configuration)
+BASELINE_MONTHLY_COST_LOW = 15.0
+BASELINE_MONTHLY_COST_HIGH = 37.0
+BASELINE_SESSIONS_PER_MONTH = 1500
+BASELINE_COST_PER_SESSION_LOW = BASELINE_MONTHLY_COST_LOW / BASELINE_SESSIONS_PER_MONTH
+BASELINE_COST_PER_SESSION_HIGH = BASELINE_MONTHLY_COST_HIGH / BASELINE_SESSIONS_PER_MONTH
+
+# Token pricing noted in MCP_SERVER_COMPARATIVE_ANALYSIS.md (OpenAI GPT-4o estimate)
+INPUT_COST_PER_MILLION = 5.0
+OUTPUT_COST_PER_MILLION = 15.0
+
+
+@dataclass
+class SessionTotals:
+    input_tokens: int = 0
+    output_tokens: int = 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build daily MCP observability cost report")
+    parser.add_argument(
+        "--log-path",
+        type=Path,
+        default=Path("observability/logs/tool_invocations.ndjson"),
+        help="Structured log path produced by mcp.observability logger.",
+    )
+    parser.add_argument(
+        "--date",
+        type=str,
+        default=date.today().isoformat(),
+        help="UTC date to aggregate (YYYY-MM-DD).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("observability/reports/daily_cost_report.json"),
+        help="Output report path.",
+    )
+    return parser.parse_args()
+
+
+def _estimate_cost_usd(input_tokens: int, output_tokens: int) -> float:
+    return round(
+        (input_tokens / 1_000_000 * INPUT_COST_PER_MILLION)
+        + (output_tokens / 1_000_000 * OUTPUT_COST_PER_MILLION),
+        6,
+    )
+
+
+def _read_events(log_path: Path, target_day: str) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    if not log_path.exists():
+        return events
+
+    with log_path.open(encoding="utf-8") as f:
+        for line in f:
+            raw = line.strip()
+            if not raw:
+                continue
+            payload = json.loads(raw)
+            ts = payload.get("ts")
+            if not ts:
+                continue
+            parsed_day = datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc).date().isoformat()
+            if parsed_day == target_day:
+                events.append(payload)
+    return events
+
+
+def build_report(events: list[dict[str, Any]], report_day: str) -> dict[str, Any]:
+    sessions: dict[str, SessionTotals] = defaultdict(SessionTotals)
+    tool_call_count: dict[str, int] = defaultdict(int)
+    tool_error_count: dict[str, int] = defaultdict(int)
+
+    for event in events:
+        event_type = event.get("event")
+        session_id = event.get("session_id") or "unknown"
+        tool_name = event.get("tool_name") or "unknown_tool"
+
+        if event_type == "tool_invocation_success":
+            sessions[session_id].input_tokens += int(event.get("token_input") or 0)
+            sessions[session_id].output_tokens += int(event.get("token_output") or 0)
+            tool_call_count[tool_name] += 1
+        elif event_type == "tool_invocation_error":
+            tool_call_count[tool_name] += 1
+            tool_error_count[tool_name] += 1
+
+    session_costs: dict[str, float] = {}
+    for session_id, totals in sessions.items():
+        session_costs[session_id] = _estimate_cost_usd(totals.input_tokens, totals.output_tokens)
+
+    avg_session_cost = round(sum(session_costs.values()) / len(session_costs), 6) if session_costs else 0.0
+    low_delta = round(avg_session_cost - BASELINE_COST_PER_SESSION_LOW, 6)
+    high_delta = round(avg_session_cost - BASELINE_COST_PER_SESSION_HIGH, 6)
+
+    tool_failure_rates: dict[str, float] = {}
+    for tool_name, count in tool_call_count.items():
+        failures = tool_error_count.get(tool_name, 0)
+        tool_failure_rates[tool_name] = round(failures / count, 6) if count else 0.0
+
+    return {
+        "report_date": report_day,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "sessions_observed": len(session_costs),
+        "per_session_average_token_cost_usd": avg_session_cost,
+        "baseline_cost_per_session_low_usd": round(BASELINE_COST_PER_SESSION_LOW, 6),
+        "baseline_cost_per_session_high_usd": round(BASELINE_COST_PER_SESSION_HIGH, 6),
+        "cost_delta_vs_baseline_low_usd": low_delta,
+        "cost_delta_vs_baseline_high_usd": high_delta,
+        "session_costs_usd": session_costs,
+        "tool_failure_rates": tool_failure_rates,
+        "source": "MCP_SERVER_COMPARATIVE_ANALYSIS.md",
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    events = _read_events(args.log_path, args.date)
+    report = build_report(events, args.date)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/observability/metrics_schema.json
+++ b/observability/metrics_schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "GPT-PANELIN MCP Observability Metrics Schema",
+  "type": "object",
+  "required": [
+    "tokens_by_session",
+    "tool_invocations",
+    "tool_errors",
+    "cache_efficiency"
+  ],
+  "properties": {
+    "tokens_by_session": {
+      "description": "Input/output token accounting grouped by session_id.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "date",
+          "session_id",
+          "token_input",
+          "token_output",
+          "total_tokens"
+        ],
+        "properties": {
+          "date": { "type": "string", "format": "date" },
+          "session_id": { "type": "string", "minLength": 1 },
+          "token_input": { "type": "integer", "minimum": 0 },
+          "token_output": { "type": "integer", "minimum": 0 },
+          "total_tokens": { "type": "integer", "minimum": 0 },
+          "estimated_cost_usd": { "type": "number", "minimum": 0 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "tool_invocations": {
+      "description": "Tool call count and latency by tool.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "date",
+          "tool_name",
+          "call_count",
+          "latency_p50_ms",
+          "latency_p95_ms",
+          "latency_avg_ms"
+        ],
+        "properties": {
+          "date": { "type": "string", "format": "date" },
+          "tool_name": { "type": "string", "minLength": 1 },
+          "call_count": { "type": "integer", "minimum": 0 },
+          "latency_p50_ms": { "type": "number", "minimum": 0 },
+          "latency_p95_ms": { "type": "number", "minimum": 0 },
+          "latency_avg_ms": { "type": "number", "minimum": 0 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "tool_errors": {
+      "description": "Tool error rates by normalized error_code.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "date",
+          "tool_name",
+          "error_code",
+          "error_count",
+          "error_rate"
+        ],
+        "properties": {
+          "date": { "type": "string", "format": "date" },
+          "tool_name": { "type": "string", "minLength": 1 },
+          "error_code": { "type": "string", "minLength": 1 },
+          "error_count": { "type": "integer", "minimum": 0 },
+          "error_rate": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "cache_efficiency": {
+      "description": "Cache hit/miss ratio by cacheable tool and day.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "date",
+          "tool_name",
+          "cache_hits",
+          "cache_misses",
+          "hit_ratio"
+        ],
+        "properties": {
+          "date": { "type": "string", "format": "date" },
+          "tool_name": { "type": "string", "minLength": 1 },
+          "cache_hits": { "type": "integer", "minimum": 0 },
+          "cache_misses": { "type": "integer", "minimum": 0 },
+          "hit_ratio": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/observability/threshold_alerts.md
+++ b/observability/threshold_alerts.md
@@ -1,0 +1,27 @@
+# Rollout Threshold Alerts (Doc-First Policy)
+
+This document defines **manual gating rules** for phased MCP rollout. Automation can be added after 2+ weeks of stable telemetry.
+
+## Alert thresholds
+
+| Metric | Warning Threshold | Pause Threshold | Action |
+|---|---:|---:|---|
+| Cost per session (daily avg) | > baseline high by 10% for 2 days | > baseline high by 20% in one day | Pause rollout stage, run cost root-cause review |
+| Tool failure rate (per tool, daily) | > 3% for 2 days | > 5% in one day | Pause rollout stage, open incident + rollback candidate |
+| Unknown tool errors | >= 1/day | >= 3/day | Pause rollout stage, validate deployment manifest |
+
+Baseline high cost/session = **$0.024667** derived from `MCP_SERVER_COMPARATIVE_ANALYSIS.md` ($37/1500 sessions).
+
+## Pause workflow
+
+1. Mark current stage as `PAUSED` in rollout tracker.
+2. Stop enabling MCP features for new users.
+3. Generate `observability/daily_cost_report.py` for the affected date.
+4. Identify top offending tool(s) and failure code(s).
+5. Require sign-off from Ops + Product before resuming stage.
+
+## Ownership
+
+- **Ops:** Monitoring + pause decision execution.
+- **Engineering:** Root-cause analysis and remediation.
+- **Product:** Resume approval after risk review.


### PR DESCRIPTION
### Motivation
- Provide structured observability for MCP tool usage to track tokens in/out, tool latency/counts, error rates, and cache efficiency to validate ROI for GitHub and Qdrant additions.  
- Enable cost control and rollout gating by surfacing per-session costs and tool failure signals so ops can pause rollout when thresholds are breached.  
- Make telemetry machine-readable and easy to roll up daily so product and ops can compare against baselines in `MCP_SERVER_COMPARATIVE_ANALYSIS.md`.

### Description
- Added a formal metrics contract at `observability/metrics_schema.json` covering `tokens_by_session`, `tool_invocations`, `tool_errors`, and `cache_efficiency`.  
- Implemented structured JSON-line logging in `mcp/observability.py` with helper functions `get_invocation_context`, `log_tool_invocation_start`, `log_tool_invocation_success`, and `log_tool_invocation_error`, writing to `observability/logs/tool_invocations.ndjson` (configurable via `MCP_TOOL_LOG_PATH`).  
- Wired logging hooks into `mcp/server.py` around the tool invocation boundary in `call_tool`, added a conservative token estimator (`_estimate_token_count`) for input/output, and added error-path logging for unknown tools and exceptions.  
- Added a daily rollup script `observability/daily_cost_report.py` that reads the structured log, computes per-session average token cost, derives deltas vs baselines from `MCP_SERVER_COMPARATIVE_ANALYSIS.md`, and emits a JSON report to `observability/reports/`.  
- Documented doc-level gating rules in `observability/threshold_alerts.md` and a concise Ops dashboard spec in `docs/mcp/observability.md` to guide alerts and ROI validation for GitHub/Qdrant additions.

### Testing
- Compiled the modified modules to validate syntax with `python -m py_compile mcp/server.py mcp/observability.py observability/daily_cost_report.py`, which succeeded.  
- Executed the daily rollup to validate runtime behavior with `python observability/daily_cost_report.py --date 2026-02-11 --output /tmp/daily_report.json`, which ran successfully and produced a JSON report (no sessions observed for that date in the test log).  
- Adjusted time-zone imports during testing (replacing `UTC` usage) and re-ran compilation and the rollup to confirm the end-to-end flow was functional.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_698ff01505b0832ea0f51a8318508eb0)